### PR TITLE
[EGD-5379] Fix static buffer between ServiceDesktop and USB

### DIFF
--- a/usb.cpp
+++ b/usb.cpp
@@ -103,10 +103,9 @@ namespace bsp
                     deviceListener->rawDataReceived(&usbSerialBuffer, dataReceivedLength);
                 }
                 else if (uxQueueSpacesAvailable(USBReceiveQueue) != 0) {
-                    static std::string receiveMessage;
-                    receiveMessage = std::string(usbSerialBuffer, dataReceivedLength);
+                    std::string *receiveMessage = new std::string(usbSerialBuffer, dataReceivedLength);
                     if (xQueueSend(USBReceiveQueue, &receiveMessage, portMAX_DELAY) == errQUEUE_FULL) {
-                        LOG_ERROR("usbDeviceTask can't send data [%s] to receiveQueue", receiveMessage.c_str());
+                        LOG_ERROR("usbDeviceTask can't send data [%s] to receiveQueue", receiveMessage->c_str());
                     }
                 }
             }


### PR DESCRIPTION
With EGD-4950 WorkerDesktop expect dynamically allocated
pointer to `std::string` to be passed in Queue between
Worker and USB