### PR TITLE
[EGD-5204] Secure USB communication

### DIFF
--- a/usb.cpp
+++ b/usb.cpp
@@ -185,6 +185,8 @@ namespace bsp
             notification = USBDeviceStatus::Disconnected;
             xQueueSend(USBIrqQueue, &notification, 0);
             break;
+        default:
+            break;
         }
     }
 } // namespace bsp


### PR DESCRIPTION
Secure all endpoints by returning 403(Forbidden) when USB is connected.
Request screen passcode to enable secured endpoints.