### PR TITLE
[EGD-6237] Add memory clearing of MTP database storage

### DIFF
--- a/mtp/mtp_db.c
+++ b/mtp/mtp_db.c
@@ -45,14 +45,14 @@ static handle_t db_alloc(struct mtp_db *db)
 static void db_free(struct mtp_db *db, handle_t handle)
 {
     db->map[handle][0] = '\0';
-    db->count++;
+    db->count--;
 }
 
 static handle_t db_search(struct mtp_db *db, const char *key)
 {
     handle_t i;
     for(i = db->highest; i > 1; i--)  {
-        if (!strncmp(db->map[i], key, 64))
+        if (!strncmp(db->map[i], key, MAX_FILENAME_LENGTH))
             return i;
     }
     return NO_HANDLE;
@@ -63,7 +63,10 @@ struct mtp_db* mtp_db_alloc(void)
     struct mtp_db *db = malloc(sizeof(struct mtp_db));
     if (!db) {
         LOG("Not enough memory!\n");
+        return NULL;
     }
+    memset(db, 0, sizeof(struct mtp_db));
+
     return db;
 }
 
@@ -83,7 +86,7 @@ uint32_t mtp_db_add(struct mtp_db *db, const char *key)
 
     handle = db_alloc(db);
     if (handle) {
-        strncpy(db->map[handle], key, 64);
+        strncpy(db->map[handle], key, MAX_FILENAME_LENGTH);
         LOG("add [%u]: %s\n", (unsigned int)handle, db->map[handle]);
         return handle;
     }

--- a/mtp/mtp_fs.cpp
+++ b/mtp/mtp_fs.cpp
@@ -18,6 +18,7 @@
 extern "C" {
 #   include "mtp_responder.h"
 #   include "mtp_db.h"
+#   include "mtp_fs.h"
 }
 
 #if 0
@@ -337,13 +338,16 @@ extern "C" struct mtp_fs* mtp_fs_alloc(void *disk)
     struct mtp_fs* fs = (struct mtp_fs*)malloc(sizeof(struct mtp_fs));
     if (fs) {
         memset(fs, 0, sizeof(struct mtp_fs));
+
         if (!(fs->db = mtp_db_alloc())) {
             free(fs);
             return NULL;
         }
+
         fs->find_data = opendir(ROOT);
+
         if (!fs->find_data) {
-            free(fs);
+            mtp_fs_free(fs);
             return NULL;
         }
     }


### PR DESCRIPTION
Clear allocated memory to avoid occasional HFs due to accessing
trashed entries