### PR TITLE
[EGD-6309] Fix 2-sec delay in VCom deinit when USB cable disconnected

### DIFF
--- a/usb.cpp
+++ b/usb.cpp
@@ -85,6 +85,7 @@ namespace bsp
     {
         LOG_INFO("usbDeinit");
         composite_deinit(usbDeviceComposite);
+        vTaskDelete(bsp::usbTaskHandle);
     }
 
     void usbReinit(const char *mtpRoot)


### PR DESCRIPTION
When USB wasn't attached, MTP task waits for configured event,
hence it cannot be joined before semaphore take times out (2 sec).