### PR TITLE
[EGD-6457] Add power management for USB

### DIFF
--- a/composite.c
+++ b/composite.c
@@ -309,6 +309,11 @@ usb_device_composite_struct_t* composite_init(userCbFunc callback, void* userArg
         LOG_ERROR("[Composite] USB Device run failed");
     }
 
+    // susspend bus if session end for USB OTG (VDD5V is not present)
+    if (USB_ANALOG_VBUS_DETECT_STAT_SESSEND(USB_ANALOG->INSTANCE[0].VBUS_DETECT_STAT)) {
+    	composite_suspend(&composite);
+    }
+
     LOG_DEBUG("[Composite] USB initialized");
     return &composite;
 }
@@ -346,4 +351,12 @@ void composite_reinit(usb_device_composite_struct_t *composite, const char *mtpR
     if (USB_DeviceRun(composite->deviceHandle) != kStatus_USB_Success) {
         LOG_ERROR("[Composite] USB Device run failed: 0x%x", err);
     }
+}
+
+void composite_suspend(usb_device_composite_struct_t *composite)
+{
+	usb_status_t err;
+	if ((err = USB_DeviceSetStatus(composite->deviceHandle, kUSB_DeviceStatusBusSuspend, NULL)) != kStatus_USB_Success) {
+		LOG_ERROR("[Composite] Device suspend failed: 0x%x", err);
+	}
 }

--- a/composite.h
+++ b/composite.h
@@ -40,6 +40,7 @@ typedef struct _usb_device_composite_struct
 usb_device_composite_struct_t *composite_init(userCbFunc callback, void *userArg);
 void composite_deinit(usb_device_composite_struct_t *composite);
 void composite_reinit(usb_device_composite_struct_t *composite, const char *mtpRoot);
+void composite_suspend(usb_device_composite_struct_t *composite);
 
 #if (defined(USB_DEVICE_CONFIG_CHARGER_DETECT) && (USB_DEVICE_CONFIG_CHARGER_DETECT > 0U)) && \
     (defined(FSL_FEATURE_SOC_USB_ANALOG_COUNT) && (FSL_FEATURE_SOC_USB_ANALOG_COUNT > 0U))

--- a/usb.cpp
+++ b/usb.cpp
@@ -99,6 +99,12 @@ namespace bsp
         composite_reinit(usbDeviceComposite, mtpRoot);
     }
 
+    void usbSuspend()
+    {
+    	LOG_INFO("usbSuspend");
+    	composite_suspend(usbDeviceComposite);
+    }
+
     void usbDeviceTask(void *handle)
     {
         USBDeviceListener *deviceListener = static_cast<USBDeviceListener *>(handle);

--- a/usb.hpp
+++ b/usb.hpp
@@ -31,6 +31,7 @@ namespace bsp
     void usbDeviceTask(void *);
     void usbDeinit();
     void usbReinit(const char *mtpRoot);
+    void usbSuspend();
 
     /* Callback fired on low level events */
     void usbDeviceStateCB(void *, vcomEvent event);

--- a/usb_device_config.h
+++ b/usb_device_config.h
@@ -134,7 +134,7 @@
 #define USB_DEVICE_CONFIG_BUFFER_PROPERTY_CACHEABLE (0U)
 #endif
 /*! @brief Whether the low power mode is enabled or not. */
-#define USB_DEVICE_CONFIG_LOW_POWER_MODE (0U)
+#define USB_DEVICE_CONFIG_LOW_POWER_MODE (1U)
 
 #if ((defined(USB_DEVICE_CONFIG_LOW_POWER_MODE)) && (USB_DEVICE_CONFIG_LOW_POWER_MODE > 0U))
 /*! @brief Whether device remote wakeup supported. 1U supported, 0U not supported */


### PR DESCRIPTION
When the USB is disconnected, we turn off the peripherals
by going into the suspend bus mode.