### PR TITLE
[EGD-7741] Optimize IObuffer size for ext4

### DIFF
--- a/mtp/mtp_fs.h
+++ b/mtp/mtp_fs.h
@@ -17,6 +17,7 @@ struct mtp_fs {
     const char *ROOT;
     DIR* find_data;
     FILE* file;
+    char* iobuf;
 };
 
 extern const struct mtp_storage_api simple_fs_api;


### PR DESCRIPTION
Optimize stdlib FILE iobuffer size for
improve transfer performance on the EXT4 fs

Signed-off-by: Lucjan Bryndza <lucjan.bryndza@mudita.com>