### PR TITLE
[EGD-8011] Fix usb deinit crash

### DIFF
--- a/composite.c
+++ b/composite.c
@@ -424,3 +424,11 @@ void composite_suspend(usb_device_composite_struct_t *composite)
 		LOG_ERROR("[Composite] Device suspend failed: 0x%x", err);
 	}
 }
+
+void composite_resume(usb_device_composite_struct_t *composite)
+{
+	usb_status_t err;
+	if ((err = USB_DeviceSetStatus(composite->deviceHandle, kUSB_DeviceStatusBusResume, NULL)) != kStatus_USB_Success) {
+		LOG_ERROR("[Composite] Device resume failed: 0x%x", err);
+	}
+}

--- a/composite.h
+++ b/composite.h
@@ -49,6 +49,7 @@ usb_device_composite_struct_t *composite_init(userCbFunc callback, void *userArg
 void composite_deinit(usb_device_composite_struct_t *composite);
 void composite_reinit(usb_device_composite_struct_t *composite, const char *mtpRoot);
 void composite_suspend(usb_device_composite_struct_t *composite);
+void composite_resume(usb_device_composite_struct_t *composite);
 
 #if (defined(USB_DEVICE_CONFIG_CHARGER_DETECT) && (USB_DEVICE_CONFIG_CHARGER_DETECT > 0U)) && \
     (defined(FSL_FEATURE_SOC_USB_ANALOG_COUNT) && (FSL_FEATURE_SOC_USB_ANALOG_COUNT > 0U))

--- a/usb.cpp
+++ b/usb.cpp
@@ -95,6 +95,11 @@ namespace bsp
 
     void usbDeinit()
     {
+        // Restart HW tick for resume operation
+        xTimerStart(usbTick, 1000);
+        // Resume if suspended
+        composite_resume(usbDeviceComposite);
+
         LOG_INFO("usbDeinit");
         composite_deinit(usbDeviceComposite);
     }

--- a/usb_device_config.h
+++ b/usb_device_config.h
@@ -142,7 +142,7 @@
 
 #if ((defined(USB_DEVICE_CONFIG_LOW_POWER_MODE)) && (USB_DEVICE_CONFIG_LOW_POWER_MODE > 0U))
 /*! @brief Whether device remote wakeup supported. 1U supported, 0U not supported */
-#define USB_DEVICE_CONFIG_REMOTE_WAKEUP (0U)
+#define USB_DEVICE_CONFIG_REMOTE_WAKEUP (1U)
 
 /*! @brief Whether LPM is supported. 1U supported, 0U not supported */
 #define USB_DEVICE_CONFIG_LPM_L1 (0U)


### PR DESCRIPTION
Fix of usb deinit crash after plugging and unplugging usb.

When USB was unplugged, the stack was suspending usb subsystem to decrease power consumption. This also caused HW crashes at the deinitialization procedure. Resuming the susbsystem just before deinit solved that issue.