### PR TITLE
[MOS-686] Stop MTP task until security is locked

### DIFF
--- a/composite.c
+++ b/composite.c
@@ -484,3 +484,10 @@ void composite_resume(usb_device_composite_struct_t *composite)
 		log_error("[Composite] Device resume failed: 0x%x", err);
 	}
 }
+
+void composite_startMTP(usb_device_composite_struct_t *composite)
+{
+#if defined (USB_DEVICE_CONFIG_MTP) && (USB_DEVICE_CONFIG_MTP > 0U)
+    MtpStart(&composite->mtpApp);
+#endif
+}

--- a/composite.h
+++ b/composite.h
@@ -51,6 +51,8 @@ void composite_reinit(usb_device_composite_struct_t *composite, const char *mtpR
 void composite_suspend(usb_device_composite_struct_t *composite);
 void composite_resume(usb_device_composite_struct_t *composite);
 
+void composite_startMTP(usb_device_composite_struct_t *composite);
+
 #if (defined(USB_DEVICE_CONFIG_CHARGER_DETECT) && (USB_DEVICE_CONFIG_CHARGER_DETECT > 0U)) && \
     (defined(FSL_FEATURE_SOC_USB_ANALOG_COUNT) && (FSL_FEATURE_SOC_USB_ANALOG_COUNT > 0U))
 void USB_UpdateHwTick(void);

--- a/mtp/mtp.c
+++ b/mtp/mtp.c
@@ -296,6 +296,12 @@ static void MtpTask(void *handle)
             continue;
         }
 
+        if (mtpApp->is_blocked) {
+            log_debug("[MTP] Wait for unlock security");
+            xSemaphoreTake(mtpApp->lock, portMAX_DELAY);
+            continue;
+        }
+
         xMessageBufferReset(mtpApp->inputBox);
         xMessageBufferReset(mtpApp->outputBox);
         mtp_responder_transaction_reset(mtpApp->responder);
@@ -382,6 +388,8 @@ usb_status_t MtpInit(usb_mtp_struct_t *mtpApp, class_handle_t classHandle, const
 {
     mtpApp->configured = false;
     mtpApp->is_terminated = false;
+    // we block the task until security is unlocked
+    mtpApp->is_blocked = true;
     mtpApp->classHandle = classHandle;
 
     if ((mtpApp->join = xSemaphoreCreateBinary())  == NULL) {
@@ -393,6 +401,10 @@ usb_status_t MtpInit(usb_mtp_struct_t *mtpApp, class_handle_t classHandle, const
         return kStatus_USB_AllocFail;
     }
     xSemaphoreGive(mtpApp->configuring);
+
+    if ((mtpApp->lock = xSemaphoreCreateBinary())  == NULL) {
+        return kStatus_USB_AllocFail;
+    }
 
     if ((mtpApp->inputBox = xMessageBufferCreate(CONFIG_RX_STREAM_SIZE*sizeof(rx_buffer))) == NULL) {
         return kStatus_USB_AllocFail;
@@ -433,6 +445,12 @@ void MtpDeinit(usb_mtp_struct_t *mtpApp)
         xSemaphoreGive(mtpApp->configuring);
     }
 
+    if (mtpApp->is_blocked)
+    {
+        // We return a semaphore so that the task can execute to the end
+        xSemaphoreGive(mtpApp->lock);
+    }
+
     mtpApp->in_reset = true;
     mtpApp->is_terminated = true;
 
@@ -447,11 +465,13 @@ void MtpDeinit(usb_mtp_struct_t *mtpApp)
     vStreamBufferDelete(mtpApp->inputBox);
     vSemaphoreDelete(mtpApp->join);
     vSemaphoreDelete(mtpApp->configuring);
+    vSemaphoreDelete(mtpApp->lock);
     mtpApp->responder = NULL;
     mtpApp->outputBox = NULL;
     mtpApp->outputBox = NULL;
     mtpApp->join = NULL;
     mtpApp->configuring = NULL;
+    mtpApp->lock = NULL;
     mtpRootPath[0] = '\0';
 
     log_debug("[MTP] Deinitialized");
@@ -504,4 +524,11 @@ void MtpDetached(usb_mtp_struct_t *mtpApp)
     log_debug("[MTP] MTP detached");
     mtpApp->configured = false;
     mtpApp->in_reset = true;
+}
+
+void MtpStart(usb_mtp_struct_t *mtpApp)
+{
+    log_debug("[MTP] security unlocked");
+    mtpApp->is_blocked = false;
+    xSemaphoreGive(mtpApp->lock);
 }

--- a/mtp/mtp.h
+++ b/mtp/mtp.h
@@ -18,11 +18,13 @@ typedef struct {
     uint8_t configured;
     uint8_t in_reset;
     uint8_t is_terminated;
+    bool is_blocked;
     size_t usb_buffer_size;
     MessageBufferHandle_t inputBox;
     MessageBufferHandle_t outputBox;
     SemaphoreHandle_t join;
     SemaphoreHandle_t configuring;
+    SemaphoreHandle_t lock;
     TaskHandle_t mtp_task_handle; /* USB MTP task handle */
 } usb_mtp_struct_t;
 
@@ -32,5 +34,6 @@ void MtpReset(usb_mtp_struct_t *mtpApp, uint8_t speed);
 void MtpDeinit(usb_mtp_struct_t *mtpApp);
 usb_status_t MtpReinit(usb_mtp_struct_t *mtpApp, class_handle_t classHandle, const char *mtpRoot);
 void MtpDetached(usb_mtp_struct_t *mtpApp);
+void MtpStart(usb_mtp_struct_t *mtpApp);
 
 #endif /* _MTP_H_ */

--- a/usb.cpp
+++ b/usb.cpp
@@ -100,6 +100,12 @@ namespace bsp
     	composite_suspend(usbDeviceComposite);
     }
 
+    void usbStartMTP()
+    {
+        log_debug("mtpStart");
+        composite_startMTP(usbDeviceComposite);
+    }
+
     int usbCDCReceive(void *buffer)
     {
         if (usbDeviceComposite->cdcVcom.inputStream == nullptr)

--- a/usb.hpp
+++ b/usb.hpp
@@ -31,6 +31,7 @@ namespace bsp
     void usbDeinit();
     void usbReinit(const std::string& rootPath);
     void usbSuspend();
+    void usbStartMTP();
 
     /* Callback fired on low level events */
     void usbDeviceStateCB(void *, vcomEvent event);


### PR DESCRIPTION
Task MTP stops at startup by default.
It resumes after calling MtpStart.