### PR TITLE
[MOS-744] Fix MTP integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,11 +94,6 @@ if (ENABLE_USB_MTP)
             mtp/mtp.c
             mtp/usb_device_mtp.c
     )
-    if (DEFINED WITH_MTP_SPARE_SPACE AND "${WITH_MTP_SPARE_SPACE}" GREATER 0)
-        target_compile_definitions(usb_stack PRIVATE MTP_SPARE_SPACE=${WITH_MTP_SPARE_SPACE})
-    else()
-        target_compile_definitions(usb_stack PRIVATE MTP_SPARE_SPACE=1024*1024*1024)
-    endif()
 endif()
 
 target_include_directories(usb_stack

--- a/mtp/libmtp/mtp_storage.h
+++ b/mtp/libmtp/mtp_storage.h
@@ -33,17 +33,17 @@ typedef struct mtp_storage_props {
 } mtp_storage_properties_t;
 
 typedef struct mtp_storage_api {
-    const mtp_storage_properties_t* (*get_properties)(void* arg);
+    const mtp_storage_properties_t* (*get_properties)(void *arg);
     uint32_t (*find_first)(void *arg, uint32_t parent, uint32_t *count);
-    uint32_t (*find_next)(void* arg);
-    uint64_t (*get_free_space)(void* arg);
+    uint32_t (*find_next)(void *arg);
+    uint64_t (*get_free_space)(void *arg);
     int (*stat)(void *arg, uint32_t handle, mtp_object_info_t *info);
     int (*rename)(void *arg, uint32_t handle, const char *new_name);
     int (*create)(void *arg, const mtp_object_info_t *info, uint32_t *handle);
     int (*remove)(void *arg, uint32_t handle);
     int (*open)(void *arg, uint32_t handle, const char *mode);
     int (*read)(void *arg, void *buffer, size_t count);
-    int (*write)(void *arg,void *buffer, size_t count);
+    int (*write)(void *arg, const void *buffer, size_t count);
     void (*close)(void *arg);
 } mtp_storage_api_t;
 

--- a/mtp/mtp_fs.cpp
+++ b/mtp/mtp_fs.cpp
@@ -4,336 +4,344 @@
  * Proprietary and confidential
  */
 #include <string.h>
-#include <assert.h>
-#include "FreeRTOS.h"
-
-#include <cstdio>
 #include <sys/types.h>
 #include <dirent.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <sys/statvfs.h>
-#include <purefs/filesystem_paths.hpp>
+#include "log.hpp"
+#include <filesystem>
+#include <Utils.hpp>
 
 extern "C" {
-#   include "mtp_responder.h"
-#   include "mtp_db.h"
-#   include "mtp_fs.h"
+#include "mtp_responder.h"
+#include "mtp_db.h"
+#include "mtp_fs.h"
 }
-
-#if 0
-#define LOG(...) LOG_INFO(__VA_ARGS__)
-#else
-#define LOG(...)
-#endif
-
-static mtp_storage_properties_t disk_properties =  {
-    .type = MTP_STORAGE_FIXED_RAM,
-    .fs_type = MTP_STORAGE_FILESYSTEM_FLAT,
-    .access_caps = 0x0000,
-    .capacity = 0,
-    .description = "SD Card",
-    .volume_id = "1234567890abcdef",
-};
 
 namespace
 {
-    constexpr auto getSpareSpace()
+    mtp_storage_properties_t disk_properties = {
+        .type        = MTP_STORAGE_FIXED_RAM,
+        .fs_type     = MTP_STORAGE_FILESYSTEM_FLAT,
+        .access_caps = MTP_STORAGE_READ_WRITE,
+        .capacity    = 0,
+        .description = "Storage",
+        .volume_id   = "1234567890abcdef",
+    };
+
+    constexpr auto iobuf_size = 64U * 1024U; // 64kB
+
+    bool is_dot(const char *name)
     {
-        return static_cast<std::uint64_t>(MTP_SPARE_SPACE);
+        const auto name_length = strlen(name);
+        const bool ret =
+            ((name_length == 1) && (name[0] == '.')) || ((name_length == 2) && (memcmp(name, "..", 2) == 0));
+        log_debug("is_dot: '%s': %s", name, ret ? "true" : "false");
+        return ret;
     }
-    constexpr auto iobuf_size = 64U * 1024U;
-}
 
-
-typedef struct {
-    uint32_t read;
-    uint64_t capacity;
-    uint64_t freespace;
-} fs_data_t;
-
-static int is_dot(const char *name) {
-    bool rv = ((strlen(name) == 1) && (name[0] == '.')) ||
-        ((strlen(name) == 2) && (name[0] == '.') && (name[1] == '.'));
-    LOG("is_dot: %s: %s", name, rv ? "true" : "false");
-    return rv;
-}
-
-static uint32_t count_files(DIR * find_data)
-{
-    uint32_t count = 0;
-    rewinddir(find_data);
-    struct dirent *de;
-    while ((de=readdir(find_data)))
+    uint32_t count_files(DIR *find_data)
     {
-        if (is_dot(de->d_name))
-            continue;
-       count++;
+        uint32_t count = 0;
+        rewinddir(find_data);
+        struct dirent *de;
+        while ((de = readdir(find_data)) != nullptr) {
+            if (is_dot(de->d_name)) {
+                continue;
+            }
+            count++;
+        }
+        return count;
     }
-    return count;
-}
 
-static const char *abspath(const char *rootPath, const char *filename)
-{
-    static char abs[128];
-    abs[0] = '/';
-    strncpy(&abs[1], filename, 64);
-    snprintf(abs, 128, "%s/%s", rootPath, filename);
-    return abs;
-}
-
-static const mtp_storage_properties_t* get_disk_properties(void* arg)
-{
-    fs_data_t *data = (fs_data_t*)arg;
-
-    struct statvfs stvfs {};
-    statvfs( purefs::dir::getUserDiskPath().c_str(), &stvfs);
-
-    // TODO: stats are for entire storage. If MTP is intended to expose
-    // only one directory, these stats should be recalculated
-    const auto freeSpace = stvfs.f_bsize * stvfs.f_bavail;
-    data->freespace = (getSpareSpace() > freeSpace) ? 0 : freeSpace - getSpareSpace();
-    data->capacity =  stvfs.f_frsize * stvfs.f_blocks;
-
-    disk_properties.capacity = data->capacity;
-
-    LOG("Capacity: %u MB, free: %u MB", unsigned(data->capacity/1024/1024), unsigned(data->freespace/1024/1024));
-
-    return &disk_properties;
-}
-
-static uint64_t get_free_space(void *arg)
-{
-    // TODO: see get_disk_properties
-    uint64_t size = 0;
-    struct statvfs stvfs {};
-    statvfs( purefs::dir::getUserDiskPath().c_str(), &stvfs);
-
-    size = (uint64_t(stvfs.f_bsize) * stvfs.f_bavail) - getSpareSpace();
-    LOG("Free space: %u MB", unsigned(size / 1024 / 1024));
-    return size;
-}
-
-static uint32_t fs_find_first(void *arg, uint32_t root, uint32_t *count)
-{
-    struct mtp_fs *fs = (struct mtp_fs*)arg;
-    uint32_t handle;
-    // TODO: list dir is not a good choose, as it allocates
-    // memory for all files from directory
-    // auto list = vfs.listdir(ROOT);
-    // it would be better to have iterator mapped to
-    // filesystem.
-
-    if (root != 0 && root != 0xFFFFFFFF)
-        return 0;
-
-    fs->find_data = opendir(fs->ROOT);
-    if(!fs->find_data)
+    const mtp_storage_properties_t *get_disk_properties(void *arg)
     {
-        LOG("Opendir failed");
-        return 0;
-    }
-    *count = count_files(fs->find_data);
+        const auto fs = static_cast<struct mtp_fs *>(arg);
+        struct statvfs stvfs {};
+        const auto ret = statvfs(fs->root, &stvfs);
 
-    // empty directory
-    if (*count == 0)
-        return 0;
+        if (ret == 0) {
+            [[maybe_unused]] const auto freeSpace = stvfs.f_bavail * stvfs.f_bsize;
+            const auto capacity                   = stvfs.f_blocks * stvfs.f_bsize;
+            disk_properties.capacity              = capacity;
 
-    LOG("found: %u files:", (unsigned int) *count);
-    rewinddir(fs->find_data);
-    struct dirent *de;
-    while( (de=readdir(fs->find_data)) &&  is_dot(de->d_name)) {
-        LOG("skip: %s", de->d_name);
+            log_debug("Capacity: %u MiB, free: %u MiB",
+                      static_cast<unsigned>(capacity / 1024 / 1024),
+                      static_cast<unsigned>(freeSpace / 1024 / 1024));
+        }
+        else {
+            log_debug("Failed to vfsstat %s, error %d", fs->root, errno);
+        }
+
+        return &disk_properties;
     }
-    if( !de )
+
+    uint64_t get_free_space(void *arg)
     {
-        LOG("No files found");
-        *count = 0;
-        return 0;
-    }
-    handle = mtp_db_add(fs->db, de->d_name);
-    return handle;
-}
+        const auto fs = static_cast<struct mtp_fs *>(arg);
+        uint64_t freeSpace = 0;
+        struct statvfs stvfs {};
+        const auto ret = statvfs(fs->root, &stvfs);
 
-static uint32_t fs_find_next(void* arg)
-{
-    uint32_t handle;
-    struct mtp_fs *fs = (struct mtp_fs*)arg;
-    struct dirent* de;
-    while ((de=readdir(fs->find_data))) {
-        if (is_dot(de->d_name))
-            continue;
+        if (ret == 0) {
+            freeSpace = stvfs.f_bavail * stvfs.f_bsize;
+            log_debug("Free space: %u MiB", static_cast<unsigned>(freeSpace / 1024 / 1024));
+        }
+        else {
+            log_debug("Failed to vfsstat %s, error %d", fs->root, errno);
+        }
+
+        return freeSpace;
+    }
+
+    uint32_t fs_find_first(void *arg, uint32_t root, uint32_t *count)
+    {
+        const auto fs = static_cast<struct mtp_fs *>(arg);
+        uint32_t handle;
+        // TODO: list dir is not a good choose, as it allocates
+        // memory for all files from directory
+        // auto list = vfs.listdir(root);
+        // it would be better to have iterator mapped to
+        // filesystem.
+
+        if (root != 0 && root != 0xFFFFFFFF) {
+            return 0;
+        }
+
+        fs->find_data = opendir(fs->root);
+        if (fs->find_data == nullptr) {
+            log_error("Opendir failed");
+            return 0;
+        }
+        *count = count_files(fs->find_data);
+        log_debug("Found: %u files", static_cast<unsigned>(*count));
+        if (*count == 0) {
+            return 0; // empty directory
+        }
+
+        rewinddir(fs->find_data);
+        struct dirent *de;
+        while (((de = readdir(fs->find_data)) != nullptr) && is_dot(de->d_name)) {
+            log_debug("Skip: '%s'", de->d_name);
+        }
+        if (de == nullptr) {
+            log_error("No files found");
+            *count = 0;
+            return 0;
+        }
         handle = mtp_db_add(fs->db, de->d_name);
         return handle;
     }
-    LOG("Done. No more files");
-    return 0;
-}
 
-static uint16_t ext_to_format_code(const char *filename)
-{
-    if (strstr(".jpg", filename))
-        return MTP_FORMAT_EXIF_JPEG;
-    if (strstr(".txt", filename))
-        return MTP_FORMAT_TEXT;
-    if (strstr(".wav", filename))
-        return MTP_FORMAT_WAV;
-    return MTP_FORMAT_UNDEFINED;
-}
-
-static int fs_stat(void *arg, uint32_t handle, mtp_object_info_t *info)
-{
-    struct stat statbuf;
-    struct mtp_fs *fs = (struct mtp_fs*)arg;
-    const char *filename = mtp_db_get(fs->db, handle);
-
-    if (!filename) {
-        // TODO: invalid handle
-        return -1;
-    }
-
-    LOG("[%u]: Get info for: %s", (unsigned int)handle, filename);
-
-    if (stat(abspath(fs->ROOT, filename), &statbuf)==0) {
-        memset(info, 0, sizeof(mtp_object_info_t));
-        info->storage_id = 0x00010001;
-        info->created = 1580371617;
-        info->modified = 1580371617;
-        info->format_code = ext_to_format_code(filename);
-        info->size = (uint64_t)statbuf.st_size;
-        *(uint32_t*)(info->uuid) = handle;
-        strncpy(info->filename, filename, 64);
-        return 0;
-    } else {
-        LOG("[%u]: Stat error: %s", (unsigned int)handle, filename);
-    }
-
-    return -1;
-}
-
-static int fs_rename(void *arg, uint32_t handle, const char *new_name)
-{
-    struct mtp_fs *fs = (struct mtp_fs*)arg;
-    int status;
-    const char *filename = mtp_db_get(fs->db, handle);
-
-    if (!filename)
-        return -1;
-
-    status = rename(filename, new_name);
-    if (status==0) {
-        mtp_db_update(fs->db, handle, new_name);
-        LOG("[%u]: Rename: %s -> %s", (unsigned int)handle, filename, new_name);
-    } else {
-        LOG("[%u]: Rename: %s -> %s FAILED", (unsigned int) handle, filename, new_name);
-    }
-    return status;
-}
-
-static int fs_create(void *arg, const mtp_object_info_t *info, uint32_t *handle)
-{
-    struct mtp_fs *fs = (struct mtp_fs*)arg;
-    uint32_t new_handle;
-
-    if (const auto freeSpace = get_free_space(nullptr); freeSpace < info->size) {
-        LOG("There is no space for file %s", info->filename);
-        return -1;
-    }
-    new_handle = mtp_db_add(fs->db, info->filename);
-    if (!new_handle) {
-        LOG("Map is full. Can't create: %s", info->filename);
-        return -1;
-    }
-    fs->file = std::fopen(abspath(fs->ROOT, info->filename), "w");
-    if(!fs->file) {
-        LOG("[]: freertos-fat error - ff_open(w) (create). Flush and wait");
-        return -1;
-    }
-    std::fclose(fs->file);
-    fs->file = NULL;
-    *handle = new_handle;
-    LOG("[%u]: Created: %s", (unsigned int)*handle, info->filename);
-    return 0;
-}
-
-static int fs_remove(void *arg, uint32_t handle)
-{
-    struct mtp_fs *fs = (struct mtp_fs*)arg;
-    const char *filename = mtp_db_get(fs->db, handle);
-    if (!filename) {
-        return -1;
-    }
-    unlink(abspath(fs->ROOT, filename));
-
-    LOG("[%u]: Removed: %s", (unsigned int)handle, filename);
-    mtp_db_del(fs->db, handle);
-    return 0;
-}
-
-static int fs_open(void *arg, uint32_t handle, const char *mode)
-{
-    struct mtp_fs *fs = (struct mtp_fs*)arg;
-    const char *filename = mtp_db_get(fs->db, handle);
-    if (!filename) {
-        return -1;
-    }
-    fs->file = std::fopen(abspath(fs->ROOT, filename), mode);
-    if(!fs->file) {
-        LOG("[%u]: Fail to open: %s [%s]. Flush and wait", (unsigned int)handle, filename, mode);
-        fs->iobuf = nullptr;
-    } else {
-        fs->iobuf = new(std::nothrow) char[iobuf_size];
-        if(fs->iobuf) {
-            if(setvbuf(fs->file, fs->iobuf, _IOFBF, iobuf_size)) {
-                LOG("[%u]: Unable to setvbuf errno %i", (uintptr_t)handle, errno);
+    uint32_t fs_find_next(void *arg)
+    {
+        uint32_t handle;
+        const auto fs = static_cast<struct mtp_fs *>(arg);
+        struct dirent *de;
+        while ((de = readdir(fs->find_data)) != nullptr) {
+            if (is_dot(de->d_name)) {
+                continue;
             }
-        } else {
-            LOG("[%u]: Unable to allocate iobuffer", (uintptr_t)handle);
+            handle = mtp_db_add(fs->db, de->d_name);
+            return handle;
+        }
+        log_debug("Done, no more files");
+        return 0;
+    }
+
+    uint16_t ext_to_format_code(const char *name)
+    {
+        const auto extension = std::filesystem::path(name).extension();
+        const auto extensionLowercase = utils::stringToLowercase(extension);
+
+        if (extensionLowercase == ".jpg" || extensionLowercase == ".jpeg") {
+            return MTP_FORMAT_EXIF_JPEG;
+        }
+        if (extensionLowercase == ".txt") {
+            return MTP_FORMAT_TEXT;
+        }
+        if (extensionLowercase == ".wav") {
+            return MTP_FORMAT_WAV;
+        }
+        if (extensionLowercase == ".mp3") {
+            return MTP_FORMAT_MP3;
+        }
+        if (extensionLowercase == ".flac") {
+            return MTP_FORMAT_FLAC;
+        }
+        return MTP_FORMAT_UNDEFINED;
+    }
+
+    int fs_stat(void *arg, uint32_t handle, mtp_object_info_t *info)
+    {
+        struct stat statbuf {};
+        const auto fs = static_cast<struct mtp_fs *>(arg);
+        const auto filename = mtp_db_get(fs->db, handle);
+
+        if (filename == nullptr) {
+            return -1;
+        }
+
+        log_debug("[%u]: get info for %s", static_cast<unsigned int>(handle), filename);
+        const auto absolutePath = std::string(fs->root) + std::string("/") + std::string(filename);
+
+        if (stat(absolutePath.c_str(), &statbuf) == 0) {
+            memset(info, 0, sizeof(mtp_object_info_t));
+            info->storage_id                          = 0x00010001;
+            info->created                             = statbuf.st_ctim.tv_sec;
+            info->modified                            = statbuf.st_mtim.tv_sec;
+            info->format_code                         = ext_to_format_code(filename);
+            info->size                                = statbuf.st_size;
+            *reinterpret_cast<uint32_t *>(info->uuid) = handle;
+
+            strncpy(info->filename, filename, sizeof(info->filename));
+            return 0;
+        }
+
+        log_error("[%u]: stat error %s: %d", static_cast<unsigned int>(handle), filename, errno);
+        return -1;
+    }
+
+    int fs_rename(void *arg, uint32_t handle, const char *new_name)
+    {
+        const auto fs = static_cast<struct mtp_fs *>(arg);
+        const auto filename    = mtp_db_get(fs->db, handle);
+        int status;
+
+        if (filename == nullptr) {
+            log_error("[%u]: filename is nullptr", static_cast<unsigned>(handle));
+            return -1;
+        }
+
+        status = rename(filename, new_name);
+        if (status == 0) {
+            mtp_db_update(fs->db, handle, new_name);
+            log_debug("[%u]: rename: %s -> %s", static_cast<unsigned>(handle), filename, new_name);
+        }
+        else {
+            log_error("[%u]: rename: %s -> %s FAILED", static_cast<unsigned>(handle), filename, new_name);
+        }
+        return status;
+    }
+
+    int fs_create(void *arg, const mtp_object_info_t *info, uint32_t *handle)
+    {
+        const auto fs = static_cast<struct mtp_fs *>(arg);
+        uint32_t new_handle;
+        const auto absolutePath = std::string(fs->root) + std::string("/") + std::string(info->filename);
+
+        if (const auto freeSpace = get_free_space(arg); freeSpace < info->size) {
+            log_error("There is not enough space for file %s (%llu < %llu)", info->filename, freeSpace, info->size);
+            return -1;
+        }
+        new_handle = mtp_db_add(fs->db, info->filename);
+        if (new_handle == 0) {
+            log_error("Map is full. Can't create: %s", info->filename);
+            return -1;
+        }
+
+        fs->file = std::fopen(absolutePath.c_str(), "w");
+        if (fs->file == nullptr) {
+            log_error("Failed to open %s", info->filename);
+            mtp_db_del(fs->db, new_handle); // Remove the file previously added to DB if creation failed
+            return -1;
+        }
+        std::fclose(fs->file);
+        fs->file = nullptr;
+        *handle  = new_handle;
+        log_debug("[%u]: created: %s", static_cast<unsigned>(*handle), info->filename);
+        return 0;
+    }
+
+    int fs_remove(void *arg, uint32_t handle)
+    {
+        const auto fs    = static_cast<struct mtp_fs *>(arg);
+        const auto filename = mtp_db_get(fs->db, handle);
+        if (filename == nullptr) {
+            log_error("[%u]: filename is nullptr", static_cast<unsigned>(handle));
+            return -1;
+        }
+
+        const auto absolutePath = std::string(fs->root) + std::string("/") + std::string(filename);
+        unlink(absolutePath.c_str());
+
+        log_debug("[%u]: removed: %s", static_cast<unsigned>(handle), filename);
+        mtp_db_del(fs->db, handle);
+        return 0;
+    }
+
+    int fs_open(void *arg, uint32_t handle, const char *mode)
+    {
+        const auto fs    = static_cast<struct mtp_fs *>(arg);
+        const auto filename = mtp_db_get(fs->db, handle);
+        if (filename == nullptr) {
+            log_error("[%u]: filename is nullptr", static_cast<unsigned>(handle));
+            return -1;
+        }
+
+        const auto absolutePath = std::string(fs->root) + std::string("/") + std::string(filename);
+        fs->file                = std::fopen(absolutePath.c_str(), mode);
+        if (fs->file == nullptr) {
+            log_error("[%u]: fail to open: %s [%s]. Flush and wait", static_cast<unsigned>(handle), filename, mode);
+            fs->iobuf = nullptr;
+        }
+        else {
+            fs->iobuf = new (std::nothrow) char[iobuf_size];
+            if (fs->iobuf != nullptr) {
+                if (setvbuf(fs->file, fs->iobuf, _IOFBF, iobuf_size) != 0) {
+                    log_error("[%u]: unable to setvbuf, errno %d", static_cast<uintptr_t>(handle), errno);
+                }
+            }
+            else {
+                log_error("[%u]: unable to allocate iobuffer", static_cast<uintptr_t>(handle));
+            }
+        }
+        log_debug("[%u]: opened: %s [%s]", static_cast<unsigned>(handle), filename, mode);
+        return static_cast<int>(fs->file == nullptr);
+    }
+
+    int fs_read(void *arg, void *buffer, size_t count)
+    {
+        const auto fs = static_cast<struct mtp_fs *>(arg);
+        size_t read;
+
+        if (fs->file == nullptr) {
+            return -1;
+        }
+
+        while ((read = std::fread(buffer, 1, count, fs->file)) <= 0) {
+            log_error("[]: fail to read");
+        }
+        return read;
+    }
+
+    int fs_write(void *arg, const void *buffer, size_t count)
+    {
+        const auto fs = static_cast<struct mtp_fs *>(arg);
+        if (fs->file == nullptr) {
+            return -1;
+        }
+
+        while (std::fwrite(buffer, 1, count, fs->file) != count) {
+            log_error("[]: fail to write");
+        }
+        return 0;
+    }
+
+    void fs_close(void *arg)
+    {
+        const auto fs = static_cast<struct mtp_fs *>(arg);
+
+        if (fs->file != nullptr) {
+            std::fclose(fs->file);
+            log_debug("[]: closed");
+            fs->file = nullptr;
+            delete[] fs->iobuf;
+            fs->iobuf = nullptr;
         }
     }
-    LOG("[%u]: Opened: %s [%s]", (unsigned int)handle, filename, mode);
-    return !fs->file;
-}
-
-static int fs_read(void *arg, void *buffer, size_t count)
-{
-    struct mtp_fs *fs = (struct mtp_fs*)arg;
-    size_t read;
-
-    if (!fs->file)
-        return -1;
-
-    while ((read = std::fread(buffer, 1, count, fs->file)) <= 0) {
-        LOG("[]: Fail to read");
-        //TODO: FF_SDDiskFlush(fs->disk);
-    }
-    return read;
-}
-
-static int fs_write(void *arg, void *buffer, size_t count)
-{
-    struct mtp_fs *fs = (struct mtp_fs*)arg;
-    if (!fs->file)
-        return -1;
-
-    while(std::fwrite(buffer, count, 1, fs->file) != 1) {
-        LOG("[]: Fail to write");
-        //TODO: FF_SDDiskFlush(fs->disk);
-    }
-    return 0;
-}
-
-static void fs_close(void *arg)
-{
-    struct mtp_fs *fs = (struct mtp_fs*)arg;
-    if (fs->file) {
-        std::fclose(fs->file);
-        LOG("[]: Closed");
-        fs->file = NULL;
-        delete [] fs->iobuf;
-        fs->iobuf = nullptr;
-    }
-}
+} // namespace
 
 extern "C" const struct mtp_storage_api simple_fs_api =
 {
@@ -353,20 +361,19 @@ extern "C" const struct mtp_storage_api simple_fs_api =
 
 extern "C" struct mtp_fs* mtp_fs_alloc(void *mtpRootPath)
 {
-    struct mtp_fs* fs = (struct mtp_fs*)malloc(sizeof(struct mtp_fs));
-    if (fs) {
-        memset(fs, 0, sizeof(struct mtp_fs));
-
-        if (!(fs->db = mtp_db_alloc())) {
+    struct mtp_fs *fs = (struct mtp_fs *) calloc(1, sizeof(struct mtp_fs));
+    if (fs != NULL) {
+        fs->db = mtp_db_alloc();
+        if (fs->db == NULL) {
             free(fs);
             return NULL;
         }
 
-        fs->ROOT = (const char *)mtpRootPath;
-        LOG("[] Initializing MTP root at %s", fs->ROOT);
+        fs->root = (const char *)mtpRootPath;
+        log_debug("[]: initializing MTP root at %s", fs->root);
 
-        fs->find_data = opendir(fs->ROOT);
-        if (!fs->find_data) {
+        fs->find_data = opendir(fs->root);
+        if (fs->find_data == NULL) {
             mtp_fs_free(fs);
             return NULL;
         }

--- a/mtp/mtp_fs.h
+++ b/mtp/mtp_fs.h
@@ -14,10 +14,10 @@ extern "C" {
 #endif
 struct mtp_fs {
     struct mtp_db *db;
-    const char *ROOT;
-    DIR* find_data;
-    FILE* file;
-    char* iobuf;
+    const char *root;
+    DIR *find_data;
+    FILE *file;
+    char *iobuf;
 };
 
 extern const struct mtp_storage_api simple_fs_api;


### PR DESCRIPTION
Fixed issues with integration
of MTP with filesystem:
- fixed memory corruption in get_disk_properties();
- remove spare space hack causing MTP to return
invalid free space and
capacity of the storage;
- added mtime and ctime handling;
- minor code cleanup.