### PR TITLE
[CP-1413] Windows displays wrong name of connected device

### DIFF
--- a/mtp/libmtp/mtp_responder.c
+++ b/mtp/libmtp/mtp_responder.c
@@ -233,8 +233,7 @@ int mtp_responder_set_device_info(mtp_responder_t *mtp,
     if (!info || !info->manufacturer
               || !info->model
               || !info->serial
-              || !info->version
-              || (strlen(info->serial) != 32))
+              || !info->version)
     {
         return -1;
     }


### PR DESCRIPTION
Replacing hardcoded device MTP information with information about the current product.