### PR TITLE
[MOS-890] Fix issues with long filenames

### DIFF
--- a/log.hpp
+++ b/log.hpp
@@ -5,9 +5,11 @@
 
 #ifdef USB_ENABLE_LOGS
 #include <log/log.hpp>
+#define log_info(...) LOG_INFO(__VA_ARGS__)
 #define log_debug(...) LOG_DEBUG(__VA_ARGS__)
 #define log_error(...) LOG_ERROR(__VA_ARGS__)
 #else
+#define log_info(...)
 #define log_debug(...)
 #define log_error(...)
 #endif

--- a/mtp/libmtp/mtp_responder.c
+++ b/mtp/libmtp/mtp_responder.c
@@ -13,9 +13,7 @@
 #include "mtp_container.h"
 #include "mtp_storage.h"
 #include "mtp_dataset.h"
-
-#define log_info(...) while(0) {}
-#define log_error(...) while(0) {}
+#include "log.hpp"
 
 #define UNUSED(x) do { (void)(x); } while (0)
 
@@ -687,13 +685,14 @@ static uint16_t handle_command(mtp_responder_t *mtp, const mtp_op_cntr_t *reques
 
 static uint16_t data_set_object_prop_value(mtp_responder_t *mtp, const mtp_data_cntr_t *incoming, size_t size)
 {
-    char name[128];
+    char name[MTP_STORAGE_FILENAME_LENGTH];
     uint16_t error = MTP_RESPONSE_OK;
     UNUSED(size);
 
     do {
-        int ret = deserialize_object_prop_value(mtp->transaction.prop_code, incoming->payload, name);
-        if (ret == 0) {
+        int ret = deserialize_object_prop_value(mtp->transaction.prop_code, incoming->payload, name, sizeof(name));
+        if (ret <= 0) {
+            log_error("Failed to deserialize object property value, retcode %d!", ret);
             error = MTP_RESPONSE_INVALID_OBJECT_PROP_VALUE;
             break;
         }

--- a/mtp/libmtp/mtp_storage.h
+++ b/mtp/libmtp/mtp_storage.h
@@ -9,6 +9,8 @@
 #include <stdint.h>
 #include <time.h>
 
+#define MTP_STORAGE_FILENAME_LENGTH (255 + 1)
+
 typedef struct mtp_object_info {
     uint32_t storage_id;
     time_t created;
@@ -20,7 +22,7 @@ typedef struct mtp_object_info {
     uint32_t parent;
     uint64_t size;
     uint8_t uuid[16];
-    char filename[64];
+    char filename[MTP_STORAGE_FILENAME_LENGTH];
 } mtp_object_info_t;
 
 typedef struct mtp_storage_props {
@@ -61,7 +63,7 @@ uint32_t serialize_object_info(mtp_object_info_t* info, uint8_t *data);
 uint32_t serialize_object_props_supported(uint8_t *data);
 uint32_t serialize_object_prop_desc(uint16_t prop_code, uint8_t *data);
 uint32_t serialize_object_prop_value(uint16_t prop_code, mtp_object_info_t *info, uint8_t *data);
-int deserialize_object_prop_value(uint16_t prop_code, const uint8_t *data, void *value);
+int deserialize_object_prop_value(uint16_t prop_code, const uint8_t *data, void *value, int value_size);
 
 int deserialize_object_info(const uint8_t *data, size_t length, mtp_object_info_t *info);
 

--- a/mtp/libmtp/mtp_util.c
+++ b/mtp/libmtp/mtp_util.c
@@ -67,25 +67,26 @@ int put_string(uint8_t *buffer, const char *text)
     *utf16 = 0;
 
     /* add null termination char, each char is 2 bytes, 1 byte for string length */
-    return (length + 1)*sizeof(uint16_t) + 1;
+    return 1 + ((length + 1) * sizeof(uint16_t));
 }
 
 int get_string(const uint8_t *buffer, char *text, int length)
 {
-    uint8_t parsed_len = *buffer;
-    uint16_t *unicode = (uint16_t*)&buffer[1];
+    uint8_t parsed_len = buffer[0];
+    uint16_t *unicode = (uint16_t *)&buffer[1];
     int i;
 
-    if (parsed_len > length)
+    if (parsed_len > length) {
         return -1;
+    }
 
-    for(i = 0; i < parsed_len; i++)
+    for (i = 0; i < parsed_len; i++)
     {
-        text[i] = *(char*)unicode;
+        text[i] = *(char *)unicode;
         unicode++;
     }
 
-    return 1 + parsed_len*2;
+    return 1 + (parsed_len * sizeof(uint16_t));
 }
 
 int put_date(uint8_t *buffer, time_t time)


### PR DESCRIPTION
Fix of the multiple issues that manifested
when trying to copy file with name longer
than 64 characters, which in worst scenario
would lead to OS bootloop due to filesystem
corruption.