### PR TITLE
[CP-1837] Fix MTP crashes

### DIFF
--- a/mtp/mtp_db.hpp
+++ b/mtp/mtp_db.hpp
@@ -3,29 +3,15 @@
 
 #pragma once
 
-#include <set>
+#include <map>
 #include <filesystem>
 #include <optional>
 
 namespace mtp
 {
-    using Handle = std::uint32_t;
-    class DatabaseEntry
-    {
-      public:
-        DatabaseEntry(Handle handle, std::filesystem::path filename);
-        explicit DatabaseEntry(Handle handle);
-
-        Handle get_handle() const;
-        std::filesystem::path get_filename() const;
-
-        bool operator<(const DatabaseEntry &rhs) const;
-        bool operator==(const DatabaseEntry &rhs) const;
-
-      private:
-        Handle handle;
-        std::filesystem::path filename;
-    };
+    using Handle               = std::uint32_t;
+    using PathToHandleMap      = std::map<std::filesystem::path, Handle>;
+    using HandleToInteratorMap = std::map<Handle, std::map<std::filesystem::path, Handle>::iterator>;
 
     /// FileDatabase is a container used to store MTP object handles and corresponding data
     class FileDatabase
@@ -38,13 +24,14 @@ namespace mtp
         bool remove(Handle handle);
 
         /// Try to insert entry with the specific filename. Returns assigned unique index in case of success.
-        std::optional<Handle> insert(const char *filename);
+        Handle insert(const char *filename);
 
         /// Try to update specific entry by unique handle. Returns false in case of failure
         bool update(Handle handle, const char *filename);
 
       private:
-        std::set<DatabaseEntry> entries;
+        PathToHandleMap filenameToHandle;
+        HandleToInteratorMap handleToFilename;
     };
 
 } // namespace mtp

--- a/mtp/mtp_fs.cpp
+++ b/mtp/mtp_fs.cpp
@@ -138,7 +138,7 @@ namespace
         }
 
         const auto new_handle = from_raw(fs->db).insert(de->d_name);
-        return new_handle ? *new_handle : 0;
+        return new_handle;
     }
 
     uint32_t fs_find_next(void *arg)
@@ -150,7 +150,7 @@ namespace
                 continue;
             }
             const auto new_handle = from_raw(fs->db).insert(de->d_name);
-            return new_handle ? *new_handle : 0;
+            return new_handle;
         }
         log_debug("Done, no more files");
         return 0;
@@ -249,7 +249,7 @@ namespace
         }
         if (const auto new_handle = from_raw(fs->db).insert(info->filename)) {
             log_debug("[%u]: created: %s", static_cast<unsigned>(*new_handle), info->filename);
-            *handle = *new_handle;
+            *handle = new_handle;
             return 0;
         }
         log_error("Can't create a new object: %s", info->filename);
@@ -368,7 +368,6 @@ extern "C" struct mtp_fs *mtp_fs_alloc(void *mtpRootPath)
 
         fs->root = (const char *)mtpRootPath;
         log_debug("[]: initializing MTP root at %s", fs->root);
-
         fs->find_data = opendir(fs->root);
         if (fs->find_data == NULL) {
             mtp_fs_free(fs);
@@ -382,6 +381,9 @@ extern "C" void mtp_fs_free(struct mtp_fs *fs)
 {
     if (fs->db != nullptr) {
         delete static_cast<mtp::FileDatabase *>(fs->db);
+    }
+    if (fs->find_data != NULL) {
+        closedir(fs->find_data);
     }
     free(fs);
 }


### PR DESCRIPTION
Fix the problem with database entries multiplication in mtp_db.
New entries were created without checking if they already existed in the database.