### PR TITLE
[MOS-686] Fixed MTP availability only after phone unlocked

### DIFF
--- a/mtp/mtp.h
+++ b/mtp/mtp.h
@@ -18,6 +18,7 @@ typedef struct {
     uint8_t configured;
     uint8_t in_reset;
     uint8_t is_terminated;
+    bool is_locked;
     size_t usb_buffer_size;
     MessageBufferHandle_t inputBox;
     MessageBufferHandle_t outputBox;
@@ -31,5 +32,6 @@ usb_status_t MtpInit(usb_mtp_struct_t *mtpApp, class_handle_t classHandle, const
 void MtpReset(usb_mtp_struct_t *mtpApp, uint8_t speed);
 void MtpDeinit(usb_mtp_struct_t *mtpApp);
 void MtpDetached(usb_mtp_struct_t *mtpApp);
+void MtpUnlock(usb_mtp_struct_t *mtpApp);
 
 #endif /* _MTP_H_ */

--- a/mtp/mtp_fs.cpp
+++ b/mtp/mtp_fs.cpp
@@ -248,7 +248,7 @@ namespace
             return -1;
         }
         if (const auto new_handle = from_raw(fs->db).insert(info->filename)) {
-            log_debug("[%u]: created: %s", static_cast<unsigned>(*new_handle), info->filename);
+            log_debug("[%lu]: created: %s", static_cast<unsigned long>(new_handle), info->filename);
             *handle = new_handle;
             return 0;
         }

--- a/usb.cpp
+++ b/usb.cpp
@@ -114,6 +114,12 @@ namespace bsp
         composite_deinit(usbDeviceComposite);
     }
 
+    void usbUnlockMTP()
+    {
+        log_debug("mtpUnlock");
+        MtpUnlock(&usbDeviceComposite->mtpApp);
+    }
+
     int usbCDCReceive(void *buffer)
     {
         if (usbDeviceComposite->cdcVcom.inputStream == nullptr) {


### PR DESCRIPTION
Fixed file access via MTP even when phone is not unlocked. Now access is granted when the phone is unlocked by the user entering a passcode. If the phone is not passcode protected (passcode is nor set) then access to the files is always possible via MTP.

_Related to PR in MuditaOS: https://github.com/mudita/MuditaOS/pull/4475_