### PR TITLE
[MOS-686] Fixed MTP availability only after phone unlocked 2

### DIFF
--- a/mtp/mtp.c
+++ b/mtp/mtp.c
@@ -294,6 +294,12 @@ static void MtpTask(void *handle)
             continue;
         }
 
+        if (mtpApp->is_locked) {
+            log_debug("[MTP] Wait for unlock security");
+            send_response(mtpApp, MTP_RESPONSE_ACCESS_DENIED);
+            continue;
+        }
+
         xMessageBufferReset(mtpApp->inputBox);
         xMessageBufferReset(mtpApp->outputBox);
         mtp_responder_transaction_reset(mtpApp->responder);
@@ -312,12 +318,6 @@ static void MtpTask(void *handle)
 
             if (request_len == 0) {
                 log_debug("[MTP] Expected MTP message. Reset: %s", mtpApp->in_reset ? "true" : "false");
-                continue;
-            }
-
-            if (mtpApp->is_locked) {
-                log_debug("[MTP] Wait for unlock security");
-                send_response(mtpApp, MTP_RESPONSE_ACCESS_DENIED);
                 continue;
             }
 


### PR DESCRIPTION
This is fix for Windows. It's fix for [previous fix](https://github.com/mudita/usb_stack/pull/76) witch: 

Fixed file access via MTP even when phone is not unlocked. Now access is granted when the phone is unlocked by the user entering a passcode. If the phone is not passcode protected (passcode is nor set) then access to the files is always possible via MTP.