### PR TITLE
[MOS-1006] Fix modifying data in .text section when setting SN

### DIFF
--- a/device/usb_string_descriptor.c
+++ b/device/usb_string_descriptor.c
@@ -8,66 +8,82 @@
 #include "usb.h"
 #include "usb_spec.h"
 #include "usb_misc.h"
-USB_DMA_INIT_DATA_ALIGN(USB_DATA_ALIGN_SIZE)
-uint8_t USB_StringDescriptorBuffer[128];
 
-const char* USB_STRING_VALUE[] = {
+USB_DMA_INIT_DATA_ALIGN(USB_DATA_ALIGN_SIZE) uint8_t USB_StringDescriptorBuffer[128];
+
+/* Sadly, there's no way to create statically initialized array
+ * of mutable, variable-length arrays in C: array can only hold
+ * objects of the same type, but arrays of different lengths are
+ * treated as different types. Thus, all strings need to have
+ * predefined maximum length, even though some of them are
+ * shorter than others. */
+static char usb_strings[][MAX_DESCRIPTOR_STRING_LENGTH + 1] = {
     USB_STRINGS(VALUE)
 };
 
-static const char* usb_string(uint8_t id)
+static char *get_usb_string(usb_device_string_id id)
 {
-    if (id > USB_STRING_MAX_ID)
+    if ((id <= USB_STRING_EMPTY) || (id > USB_STRING_MAX_ID)) {
         return NULL;
-    return USB_STRING_VALUE[id];
+    }
+    return usb_strings[id - 1];
 }
 
 static uint16_t languages_descriptor(uint8_t *ptr)
 {
-    *ptr++ = 4;
+    const uint8_t size = 4;
+    *ptr++ = size;
     *ptr++ = USB_DESCRIPTOR_TYPE_STRING;
     *ptr++ = 0x09;
     *ptr++ = 0x04;
-    return 4;
+    return size;
 }
 
 static uint16_t string_descriptor(uint8_t *ptr, const char *ascii)
 {
-    uint16_t *utf16;
-    uint8_t len = strlen(ascii);
-    uint8_t total = 2 + 2*len;
-    int i;
-    *ptr++ = total;
+    const uint8_t len = strlen(ascii);
+    const uint8_t size = 2 + sizeof(uint16_t) * len;
+
+    *ptr++ = size;
     *ptr++ = USB_DESCRIPTOR_TYPE_STRING;
-    utf16 = (uint16_t*)ptr;
-    for(i = 0; i < len; i++)
-        *utf16++ = (uint16_t)ascii[i];
 
-    return total;
+    uint16_t *utf16 = (uint16_t *)ptr;
+    for (size_t i = 0; i < len; i++) {
+        *utf16++ = (uint16_t) ascii[i];
+    }
+
+    return size;
 }
 
-uint16_t USB_StringDescriptor(void* buffer, uint8_t id)
+uint16_t USB_GetStringDescriptor(void *buffer, usb_device_string_id id)
 {
-    uint8_t* ptr = buffer;
-    const char *ascii;
-    if (id == 0)
+    uint8_t *ptr = buffer;
+    if (id == USB_STRING_EMPTY) {
         return languages_descriptor(ptr);
-    ascii = usb_string(id - 1);
-    if (ascii) {
-        return string_descriptor(ptr, ascii);
     }
-    return 0;
+
+    const char *usb_string = get_usb_string(id);
+    if (usb_string == NULL) {
+        return 0;
+    }
+
+    return string_descriptor(ptr, usb_string);
 }
 
-uint16_t USB_DeviceSetStringDescriptor(uint8_t id, const char *ascii)
+uint16_t USB_SetDescriptorString(const char *descriptor, usb_device_string_id id)
 {
-    char *ptr = usb_string(id - 1);
-    if (ptr) {
-        size_t len = MIN(strlen(ptr), strlen(ascii));
-        strncpy(ptr, ascii, len);
-        ptr[len] = '\0';
-        return len;
+    char *usb_string = get_usb_string(id);
+    if (usb_string == NULL) {
+        return 0;
     }
 
-    return 0;
+    const uint16_t len = MIN(strlen(descriptor), MAX_DESCRIPTOR_STRING_LENGTH);
+    memcpy(usb_string, descriptor, len);
+    usb_string[len] = '\0';
+    return len;
+}
+
+const char *USB_GetDescriptorStringPtr(usb_device_string_id id)
+{
+    return get_usb_string(id);
 }

--- a/device/usb_string_descriptor.h
+++ b/device/usb_string_descriptor.h
@@ -21,8 +21,11 @@
  * For enum, there is prefix added: USB_STRING_.
  */
 #include "usb_strings.h"
+
+#define MAX_DESCRIPTOR_STRING_LENGTH 36
+
 #define ID(id, value) USB_STRING_##id
-#define VALUE(id,value) value
+#define VALUE(id, value) value
 
 typedef enum {
     USB_STRING_EMPTY = 0,
@@ -32,23 +35,27 @@ typedef enum {
 
 /*
  * @brief Returns USB string descriptor for id
- * @param buffer for descritor's binary data
- * @param id of string to be put in descritor
- * @return length of descriptor's binary data or 0
- *         for non-existing string
+ * @param buffer for descriptor's binary data
+ * @param id of string descriptor to be read
+ * @return length of descriptor's binary data or 0 for non-existing string
  */
-uint16_t USB_StringDescriptor(void* buffer, uint8_t id);
+uint16_t USB_GetStringDescriptor(void *buffer, usb_device_string_id id);
 
 /*
- * @brief Returns USB string descriptor for id
- * @param buffer for descritor's binary data
- * @param id of string to be put in descritor
- * @return length of descriptor's binary data or 0
- *         for non-existing string
+ * @brief Sets new value of descriptor string
+ * @param data to be set as descriptor string
+ * @param id of string to be set
+ * @return length of descriptor's binary data or 0 for non-existing string
  */
-uint16_t USB_DeviceSetStringDescriptor(uint8_t id, const char *ascii);
+uint16_t USB_SetDescriptorString(const char *descriptor, usb_device_string_id id);
 
-/**/
+/*
+ * @brief Returns pointer to descriptor string
+ * @param id of string to be read
+ * @return pointer to descriptor string
+ */
+const char *USB_GetDescriptorStringPtr(usb_device_string_id id);
+
 extern uint8_t USB_StringDescriptorBuffer[];
 #endif /*_USB_STRING_DESCRIPTOR_H */
 

--- a/mtp/mtp.c
+++ b/mtp/mtp.c
@@ -36,14 +36,14 @@ USB_GLOBAL USB_RAM_ADDRESS_ALIGNMENT(USB_DATA_ALIGN_SIZE) static char mtpRootPat
 
 #define MTP_TASK_STACK_SIZE (3U * 1024U)
 
-static const char *DEVICE_STRING_VALUE[] = {USB_STRINGS(VALUE)};
-static mtp_device_info_t getDevice()
+static mtp_device_info_t getDevice(void)
 {
-    const int indexOffset    = 1;
-    mtp_device_info_t device = {.manufacturer = DEVICE_STRING_VALUE[USB_STRING_MANUFACTURER - indexOffset],
-                                .model        = DEVICE_STRING_VALUE[USB_STRING_PRODUCT - indexOffset],
-                                .version      = "1",
-                                .serial       = DEVICE_STRING_VALUE[USB_STRING_SERIAL_NUMBER - indexOffset]};
+    mtp_device_info_t device = {
+            .manufacturer = USB_GetDescriptorStringPtr(USB_STRING_MANUFACTURER),
+            .model        = USB_GetDescriptorStringPtr(USB_STRING_PRODUCT),
+            .version      = "1",
+            .serial       = USB_GetDescriptorStringPtr(USB_STRING_SERIAL_NUMBER)
+    };
     return device;
 }
 

--- a/usb_device_descriptor.c
+++ b/usb_device_descriptor.c
@@ -404,14 +404,13 @@ usb_status_t USB_DeviceGetConfigurationDescriptor(
 usb_status_t USB_DeviceGetStringDescriptor(usb_device_handle handle,
                                            usb_device_get_string_descriptor_struct_t *stringDescriptor)
 {
-    uint16_t length = USB_StringDescriptor(USB_StringDescriptorBuffer, stringDescriptor->stringIndex);
-    if (length) {
+    const uint16_t length = USB_GetStringDescriptor(USB_StringDescriptorBuffer, stringDescriptor->stringIndex);
+    if (length > 0) {
         stringDescriptor->buffer = USB_StringDescriptorBuffer;
         stringDescriptor->length = length;
         return kStatus_USB_Success;
-    } else {
-        return kStatus_USB_Error;
     }
+    return kStatus_USB_Error;
 }
 
 /*!
@@ -609,7 +608,7 @@ usb_status_t USB_DeviceSetSpeed(usb_device_handle handle, uint8_t speed)
 
 uint16_t USB_DeviceSetSerialNumberString(const char *serialNumberAscii)
 {
-    return USB_DeviceSetStringDescriptor(USB_STRING_SERIAL_NUMBER, serialNumberAscii);
+    return USB_SetDescriptorString(serialNumberAscii, USB_STRING_SERIAL_NUMBER);
 }
 
 uint16_t USB_DeviceSetBcdVersion(usb_device_handle *handle, const uint16_t version)


### PR DESCRIPTION
Fix of the issue that setting serial number in
USB stack resulted in writing to read-only
.text section, what causes undefined behavior.