### PR TITLE
[BH-2002] Fix memory leak in VirtualComDeinit

### DIFF
--- a/composite.c
+++ b/composite.c
@@ -334,10 +334,10 @@ usb_device_composite_struct_t *composite_init(usb_event_callback_t userEventCall
 
     composite.speed                       = USB_SPEED_FULL;
     composite.attach                      = 0;
-    composite.cdcVcom.cdcAcmHandle        = (class_handle_t)NULL;
     composite.deviceHandle                = NULL;
     composite.userDefinedEventCallback    = userEventCallback;
     composite.userDefinedEventCallbackArg = NULL; // not used
+    memset(&composite.cdcVcom, 0, sizeof(composite.cdcVcom));
 
     if ((serialNumber != NULL) && (serialNumber[0] != '\0')) {
         USB_DeviceSetSerialNumberString(serialNumber);

--- a/device/ehci/usb_device_ehci.h
+++ b/device/ehci/usb_device_ehci.h
@@ -31,7 +31,8 @@
 /*! @brief The maximum value of control type maximum packet size for HS in USB specification 2.0 */
 #define USB_DEVICE_MAX_HS_CONTROL_MAX_PACKET_SIZE (64U)
 
-#define USB_DEVICE_MAX_TRANSFER_PRIME_TIMES (10000000U)  /* The max prime times of EPPRIME, if still doesn't take effect, means status has been reset*/
+/*! @brief The max prime times of EPPRIME, if still doesn't take effect, means status has been reset */
+#define USB_DEVICE_MAX_TRANSFER_PRIME_TIMES (1000000U)
 
 /* Device QH */
 #define USB_DEVICE_EHCI_QH_POINTER_MASK (0xFFFFFFC0U)


### PR DESCRIPTION
* Fix of the issue that StreamBuffers were 
not  freed in case VCOM wasn't fully
configured before deinitialization.
* Reduced EPPRIME max retries to 1e6 
instead of 1e7, which was too much and
made device unresponsive when 
connected with broken USB cable.